### PR TITLE
Typos shor algorithm ipynb

### DIFF
--- a/chapter08/cirq/shor.ipynb
+++ b/chapter08/cirq/shor.ipynb
@@ -378,9 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -453,7 +451,7 @@
     "    where y is the target register, e is the exponent register, x is the base\n",
     "    and n is the modulus. Consequently,\n",
     "\n",
-    "        V|y⟩|e⟩ = (U**e|r⟩)|e⟩\n",
+    "        V|y⟩|e⟩ = (U**e|y)|e⟩\n",
     "\n",
     "    where U is the unitary defined as\n",
     "\n",
@@ -1087,9 +1085,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/chapter08/cirq/shor.ipynb
+++ b/chapter08/cirq/shor.ipynb
@@ -289,7 +289,7 @@
     "        return self.target_register, self.input_register\n",
     "    \n",
     "    def with_registers(self, *new_registers):\n",
-    "        return Add(*new_registers)\n",
+    "        return Adder(*new_registers)\n",
     "    \n",
     "    def apply(self, target_value, input_value):\n",
     "        return target_value + input_value"
@@ -434,7 +434,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "\"\"\"Defines the modular exponential operation used in Shor's algorithm.\"\"\"\n",


### PR DESCRIPTION
Chapter 8 the [Shor Algorithm](https://github.com/kikejimenez/quantumcomputingbook/blob/master/chapter08/cirq/shor.ipynb), the following changes were applied:
 -  In the documentation of class `ModularExp`, replace  _\|r>_  with _\|y>_
 -  In the `with_registers` in  `Adder` class, replace  `Add` with `Adder`