### PR TITLE
Flips the result measurement display

### DIFF
--- a/chapter07/cirq/superdense-coding-cirq.py
+++ b/chapter07/cirq/superdense-coding-cirq.py
@@ -42,4 +42,4 @@ sim = cirq.Simulator()
 res = sim.run(circ, repetitions=1)
 
 # Print out Bob's received message: the outcome of the circuit
-print("\nBob's received message =", bitstring(res.measurements.values()))
+print("\nBob's received message =", bitstring(res.measurements.values())[::-1])


### PR DESCRIPTION
When ran, Bob's received message was printing flipped (i.e. it printed "01" when it received "10"). The issue wasn't in the measurement, because when printing "res.measurements" it correctly assigned the values to the qubits from the message as expected.

This correction flips the bitstring display so it prints the message correctly.

The error might come from a change in how cirq saves measurements from simulators, but I'm not sure.