### PR TITLE
qnn.py update for most recent versions of Cirq (v0.11+)

### DIFF
--- a/chapter09/cirq/qnn.py
+++ b/chapter09/cirq/qnn.py
@@ -7,8 +7,7 @@ import numpy as np
 import sympy
 
 # Class for a ZX gate in Cirq
-class ZXGate(cirq.ops.eigen_gate.EigenGate,
-             cirq.ops.gate_features.TwoQubitGate):
+class ZXGate(cirq.ops.eigen_gate.EigenGate):
   """ZXGate with variable weight."""
 
   def __init__(self, weight=1):
@@ -19,6 +18,10 @@ class ZXGate(cirq.ops.eigen_gate.EigenGate,
     """
     self.weight = weight
     super().__init__(exponent=weight) # Automatically handles weights other than 1
+  def _num_qubits_(self):
+      """Indicates the number of qubits
+      replaces inheriting the superclass TwoQubitGate"""
+      return 2
 
   def _eigen_components(self):
     return [
@@ -33,7 +36,7 @@ class ZXGate(cirq.ops.eigen_gate.EigenGate,
     ]
 
   # This lets the weight be a Symbol. Useful for parameterization.
-  def _resolve_parameters_(self, param_resolver):
+  def _resolve_parameters_(self, param_resolver, recursive=True):
     return ZXGate(weight=param_resolver.value_of(self.weight))
 
   # How should the gate look in ASCII diagrams?
@@ -76,7 +79,7 @@ def readout_expectation(state):
   # Specify an explicit qubit order so that we know which qubit is the readout
   result = simulator.simulate(qnn, resolver, qubit_order=[readout]+data_qubits,
                               initial_state=state_num)
-  wf = result.final_state
+  wf = result.final_state_vector
 
   # Becase we specified qubit order, the Z value of the readout is the most
   # significant bit.

--- a/chapter09/cirq/qnn.py
+++ b/chapter09/cirq/qnn.py
@@ -18,6 +18,7 @@ class ZXGate(cirq.ops.eigen_gate.EigenGate):
     """
     self.weight = weight
     super().__init__(exponent=weight) # Automatically handles weights other than 1
+
   def _num_qubits_(self):
       """Indicates the number of qubits
       replaces inheriting the superclass TwoQubitGate"""


### PR DESCRIPTION
Hello,

As discussed in issues, here is a pull request with a small update on chapter 9's `qnn.py` script.
The following changes have been made:

1. (**add-on compared to opened issue**) Removal of `TwoQubitGate` from the inheritance arguments of class `ZXGate` (lines 10-11) as it will be deprecated with cirq v0.14 onward. This is replaced with overriding the function `_num_qubits_` in the body of the class such that:
```python
def _num_qubits_(self):
        return 2
```
2. Addition of the `recursive:bool` argument to the override of the function `_resolve_parameters_` (line 36) in the body of custom class `ZXGate` so as to work with cirq versions v0.11 and further.
3. Replacement of `wf = result.final_state` with `wf = result.final_state_vector` (line 79) in the body of function `readout_expectation`.

Best regards,

Quentin